### PR TITLE
Fix TypeScript Error by Updating Replace Function Arguments

### DIFF
--- a/source/ContentScript/index.ts
+++ b/source/ContentScript/index.ts
@@ -54,7 +54,8 @@ function replaceInTextNode(node: Text): void {
   const original = node.nodeValue;
   if (!original) return;
 
-  const replaced = original.replace(WORD_REGEX, (match, base: string, plural: string | undefined) => {
+  const replaced = original.replace(WORD_REGEX, (match, ...args: unknown[]) => {
+    const plural = args[1] as string | undefined;
     const replacementFull = REPLACEMENT_BASE + (plural ? 's' : '');
     return applyCasing(match, replacementFull);
   });


### PR DESCRIPTION
This pull request addresses a TypeScript compilation error by modifying the arguments of the `replace` function in `index.ts`. The variable `base`, which was declared but never used, has been removed. Instead, the function now uses the rest parameters (`...args`) to access the necessary values. This change resolves the TypeScript error TS6133 and ensures that the code complies with the typing requirements.

---

> This pull request was co-created with Cosine Genie

Original Task: [browser-extension/7fignpoaazky](https://cosine.wtf/cosine-stg/browser-extension/task/7fignpoaazky)
Author: Curtis Huang
