### PR TITLE
Upgrade manifest version to 3 for compatibility

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Sample WebExtension",
   "version": "0.0.0",
 
@@ -15,12 +15,16 @@
 
   "permissions": [
     "activeTab",
-    "storage",
+    "storage"
+  ],
+  "host_permissions": [
     "http://*/*",
     "https://*/*"
   ],
 
-  "content_security_policy": "script-src 'self'; object-src 'self'",
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
 
   "__chrome|firefox__author": "abhijithvijayan",
   "__opera__developer": {
@@ -33,10 +37,10 @@
     }
   },
 
-  "__chrome__minimum_chrome_version": "49",
+  "__chrome__minimum_chrome_version": "88",
   "__opera__minimum_opera_version": "36",
 
-  "browser_action": {
+  "action": {
     "default_popup": "popup.html",
     "default_icon": {
       "16": "assets/icons/favicon-16.png",
@@ -44,32 +48,27 @@
       "48": "assets/icons/favicon-48.png",
       "128": "assets/icons/favicon-128.png"
     },
-    "default_title": "tiny title",
-    "__chrome|opera__chrome_style": false,
-    "__firefox__browser_style": false
+    "default_title": "tiny title"
   },
 
-  "__chrome|opera__options_page": "options.html",
   "options_ui": {
     "page": "options.html",
-    "open_in_tab": true,
-    "__chrome__chrome_style": false
+    "open_in_tab": true
   },
 
   "background": {
-    "scripts": [
-      "js/background.bundle.js"
-    ],
-    "__chrome|opera__persistent": false
+    "service_worker": "js/background.bundle.js"
   },
 
-  "content_scripts": [{
-    "matches": [
-      "http://*/*",
-      "https://*/*"
-    ],
-    "js": [
-      "js/contentScript.bundle.js"
-    ]
-  }]
+  "content_scripts": [
+    {
+      "matches": [
+        "http://*/*",
+        "https://*/*"
+      ],
+      "js": [
+        "js/contentScript.bundle.js"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This pull request updates the extension's manifest file from version 2 to version 3, addressing installation issues due to unsupported manifest versions. Key changes include modifications to the `background` property by switching from `scripts` to `service_worker`, the addition of `host_permissions`, and several adjustments to ensure compatibility with the latest browser requirements. These changes resolve the issue of the extension not loading due to an outdated manifest version.

---

> This pull request was co-created with Cosine Genie

Original Task: [browser-extension/jeqfradc5p4p](https://cosine.wtf/cosine-stg/browser-extension/task/jeqfradc5p4p)
Author: Curtis Huang
