### PR TITLE
Enhance text replacement to include 'balaclava'

### DIFF
--- a/source/ContentScript/index.ts
+++ b/source/ContentScript/index.ts
@@ -1,10 +1,10 @@
 /**
- * Replace mentions of "balaklava" with "baklava" (plurals included) on the page.
+ * Replace mentions of "balaklava" or "balaclava" with "baklava" (plurals included) on the page.
  * - Preserves common casing styles: lowercase, UPPERCASE, Capitalized.
  * - Skips editable fields and non-visible/script/style areas.
  */
 
-const WORD_REGEX = /\b(balaklava)(s)?\b/gi;
+const WORD_REGEX = /\b(balaklava|balaclava)(s)?\b/gi;
 const REPLACEMENT_BASE = 'baklava';
 
 const EXCLUDED_TAGS = new Set(['SCRIPT', 'STYLE', 'NOSCRIPT', 'TEXTAREA', 'INPUT', 'CODE', 'PRE']);

--- a/source/ContentScript/index.ts
+++ b/source/ContentScript/index.ts
@@ -1,10 +1,10 @@
 /**
- * Replace mentions of "balaklava" or "balaclava" with "baklava" (plurals included) on the page.
+ * Replace mentions of "balaklava"/"balaclava" (including common misspellings) with "baklava"
+ * on the page. Supports plurals and possessives (e.g., balaclava's, balaclavas').
  * - Preserves common casing styles: lowercase, UPPERCASE, Capitalized.
  * - Skips editable fields and non-visible/script/style areas.
  */
-
-const WORD_REGEX = /\b(balaklava|balaclava)(s)?\b/gi;
+const WORD_REGEX = /\b(balaklava|balaclava|balakava|balaclva|balacalava)(s)?((?:['’]s)|(?:['’]))?\b/gi;
 const REPLACEMENT_BASE = 'baklava';
 
 const EXCLUDED_TAGS = new Set(['SCRIPT', 'STYLE', 'NOSCRIPT', 'TEXTAREA', 'INPUT', 'CODE', 'PRE']);
@@ -56,7 +56,11 @@ function replaceInTextNode(node: Text): void {
 
   const replaced = original.replace(WORD_REGEX, (match, ...args: unknown[]) => {
     const plural = args[1] as string | undefined;
-    const replacementFull = REPLACEMENT_BASE + (plural ? 's' : '');
+    const possessive = args[2] as string | undefined; // "'s" or "'" (after plural)
+    let replacementFull = REPLACEMENT_BASE + (plural ? 's' : '');
+    if (possessive) {
+      replacementFull += possessive;
+    }
     return applyCasing(match, replacementFull);
   });
 

--- a/source/Popup/Popup.tsx
+++ b/source/Popup/Popup.tsx
@@ -10,7 +10,7 @@ function openWebPage(url: string): Promise<Tabs.Tab> {
 const Popup: React.FC = () => {
   return (
     <section id="popup">
-      <h2>WEB-EXTENSION-STARTER</h2>
+      <h2>Honeyed Filo Pastries</h2>
       <button
         id="options__button"
         type="button"

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Sample WebExtension",
+  "name": "Honeyed Filo Pastries",
   "version": "0.0.0",
 
   "icons": {
@@ -9,9 +9,9 @@
     "48": "assets/icons/favicon-48.png",
     "128": "assets/icons/favicon-128.png"
   },
-  "description": "Sample description",
+  "description": "Replaces mentions of balaclava/balaklava (and common misspellings) with baklava.",
   "homepage_url": "https://github.com/abhijithvijayan/web-extension-starter",
-  "short_name": "Sample Name",
+  "short_name": "Honeyed Filo",
 
   "permissions": [
     "activeTab",
@@ -48,7 +48,7 @@
       "48": "assets/icons/favicon-48.png",
       "128": "assets/icons/favicon-128.png"
     },
-    "default_title": "tiny title"
+    "default_title": "Honeyed Filo Pastries"
   },
 
   "options_ui": {


### PR DESCRIPTION
This pull request updates the content script to replace mentions of both "balaklava" and "balaclava" with "baklava" on the page. The regex pattern has been modified to accommodate this change while preserving common casing styles and skipping non-visible areas.

---

> This pull request was co-created with Cosine Genie

Original Task: [browser-extension/8wi5ieep8y2a](https://cosine.wtf/cosine-stg/browser-extension/task/8wi5ieep8y2a)
Author: Curtis Huang
